### PR TITLE
Small refactor: remove Error string, use a builder for Swicket, more compact syntax

### DIFF
--- a/provider/github.go
+++ b/provider/github.go
@@ -2,6 +2,7 @@ package provider
 
 import (
 	"encoding/json"
+	"errors"
 	"fmt"
 	"io/ioutil"
 	"log"
@@ -14,25 +15,29 @@ func (GitHub) IsActive() bool {
 	return true
 }
 
-func (GitHub) GetLatestVersion() string {
-	res, err := http.Get("https://api.github.com/repos/alfio-event/alf.io/releases")
+func (GitHub) GetLatestVersion() (string, error) {
+	response, err := http.Get("https://api.github.com/repos/alfio-event/alf.io/releases")
 	if err != nil {
-		log.Fatal(err)
-		return Error
+		log.Printf("could not fetch version from Github: %v", err)
+		return "", err
 	}
-	rel, err := ioutil.ReadAll(res.Body)
-	res.Body.Close()
+	release, err := ioutil.ReadAll(response.Body)
 	if err != nil {
-		return Error
+		log.Printf("could not read release page content from Github: %v", err)
+		return "", err
 	}
-	r := findLatestRelease(rel)
-	if r != nil {
-		return r["tag_name"].(string)
+	defer response.Body.Close()
+
+	if r := findLatestRelease(release); r != nil {
+		return r["tag_name"].(string), nil
 	}
-	return Error
+	return "", errors.New("could not get the latest release version from Github")
 }
 
 func findLatestRelease(rel []byte) map[string]interface{} {
+	// it would be great if there was a Github client that could expose a struct
+	// to map response to, so instead of unmarshalling to interface{} and casting
+	// there would be a concrete type to work with
 	var dat []map[string]interface{}
 	if err := json.Unmarshal(rel, &dat); err != nil {
 		return nil

--- a/provider/swicket.go
+++ b/provider/swicket.go
@@ -5,14 +5,32 @@ import (
 	"os"
 )
 
-type Swicket struct{}
-
-func (Swicket) IsActive() bool {
-	return len(os.Getenv("SWICKET_CLIENT_ID")) > 0 && len(os.Getenv("SWICKET_CLIENT_SECRET")) > 0
+// You could think of embedding the clientID and client_secret into the type
+// so that you can build heper methods to fetch them from os.ENV instead of getting them directly
+// this could help you validate the Switcket struct earlier on and decouples you from
+// how you instantiate the type
+type Swicket struct {
+	clientID,
+	clientSecret string
 }
 
-func (Swicket) GetLatestVersion() string {
-	return "WIP"
+func NewSwicketFromEnv() *Swicket {
+	return &Swicket{
+		clientID:     os.Getenv("SWICKET_CLIENT_ID"),
+		clientSecret: os.Getenv("SWICKET_CLIENT_SECRET"),
+	}
+}
+
+func (s *Swicket) valid() bool {
+	return s.clientID != "" && s.clientSecret != ""
+}
+
+func (s Swicket) IsActive() bool {
+	return s.valid()
+}
+
+func (Swicket) GetLatestVersion() (string, error) {
+	return "WIP", nil
 }
 
 func (Swicket) GetArtifactUrl(version string) string {

--- a/provider/versionprovider.go
+++ b/provider/versionprovider.go
@@ -2,9 +2,20 @@ package provider
 
 type VersionProvider interface {
 	IsActive() bool
-	GetLatestVersion() string
+	// always good to return error in its type instead of strings
+	GetLatestVersion() (string, error)
 	GetArtifactUrl(version string) string
 	Name() string
 }
 
-const Error = "ERROR"
+// if you want custom errors, you can implement your own imeplemting the error interface
+
+// ProviderError implements the error interface and can be used as en error in function returns
+type ProviderError struct {
+	something string
+}
+
+// just an example to show how inner atteributes can contribute in building an error
+func (p ProviderError) Error() string {
+	return p.something
+}

--- a/urbano.go
+++ b/urbano.go
@@ -1,6 +1,7 @@
 package main
 
 import (
+	"flag"
 	"fmt"
 	"log"
 	"os"
@@ -13,36 +14,46 @@ import (
 )
 
 func main() {
-	providers := getActiveProviders()
+	// using command-line flags instead of os.Args makes it more reusable plus you get '--help' for free
+	outDir := flag.String("-outdir", "/home/alfio", "Output directory")
+	flag.Parse()
 
+	providers := getActiveProviders()
 	if len(providers) == 0 {
 		log.Fatal("no active providers have been found. Aborting.")
 	}
-	outDir := "/home/alfio"
-	if len(os.Args) > 1 {
-		outDir = os.Args[1]
-	}
+
+	// probably you need a factory to choose which one should be used
 	p := providers[0]
-	v := p.GetLatestVersion()
-	if v == provider.Error {
-		log.Fatal("Got Error from provider [", p.Name(), "]")
+	v, err := p.GetLatestVersion()
+	if err != nil {
+		log.Fatalf("Got error from provider [%s]: %v", p.Name(), err)
 	}
+
 	url := p.GetArtifactUrl(v)
-	outFile := filepath.Join(outDir, fmt.Sprintf("/alfio-%s-boot.war", v))
+	outFile := filepath.Join(*outDir, fmt.Sprintf("alfio-%s-boot.war", v))
 	log.Print("Provider [", p.Name(), "] says: ", v)
+	// if-else is discouraged, always better to use naked return in main when you want to interrupt flow
 	if _, err := os.Stat(outFile); os.IsNotExist(err) {
 		log.Print("About to download ", url, " => ", outFile)
 		downloadNewRelease(url, outFile)
 		performDeployment(outFile)
-	} else {
-		log.Print("File ", outFile, " exists, nothing to be done here.")
+		return
 	}
+	// else {
+	log.Print("File ", outFile, " exists, nothing to be done here.")
+	//}
 }
 
 //source: https://github.com/cavaliercoder/grab
 func downloadNewRelease(url string, to string) {
 	client := grab.NewClient()
-	req, _ := grab.NewRequest(to, url)
+	req, err := grab.NewRequest(to, url)
+	// never discard errors
+	if err != nil {
+		log.Printf("could not create client to download new release: %v", err)
+		return
+	}
 
 	// start download
 	log.Print("Downloading ", req.URL(), "...")
@@ -56,7 +67,7 @@ Loop:
 	for {
 		select {
 		case <-t.C:
-			log.Printf("  transferred %v / %v bytes (%.2f%%)",
+			log.Printf("  transferred %d / %d bytes (%.2f%%)",
 				resp.BytesComplete(),
 				resp.Size,
 				100*resp.Progress())
@@ -87,13 +98,11 @@ Loop:
 func performDeployment(artifactPath string) error {
 
 	log.Print("Performing deployment of ", artifactPath)
-
 	if err := callSystemCtl("stop"); err != nil {
 		log.Fatal(err)
 	}
 
 	log.Print("delete symlink ")
-
 	symlinkPath := filepath.Join(filepath.Dir(artifactPath), "alfio-boot.war")
 	if _, err := os.Lstat(symlinkPath); err == nil {
 		log.Print("removing symlink ", symlinkPath)
@@ -101,19 +110,16 @@ func performDeployment(artifactPath string) error {
 	}
 
 	log.Print("recreate symlink ")
-
 	if err := os.Symlink(artifactPath, symlinkPath); err != nil {
 		log.Fatal(err)
 	}
 
 	log.Print("restart service")
-
 	return callSystemCtl("start")
 }
 
 func callSystemCtl(command string) error {
-	cmd := exec.Command("/usr/bin/systemctl", command, "alfio")
-	return cmd.Run()
+	return exec.Command("/usr/bin/systemctl", command, "alfio").Run()
 }
 
 func getActiveProviders() (ret []provider.VersionProvider) {


### PR DESCRIPTION
Hi :) 

the code looks good! I especially like the part on HTTP GET download progress made with channels.
This PR is just adding a couple of error checks (errors should never be discarded) and a syntactic refinement of the `provider` package on the implementation of the `VersionProvider` interface in type `Swicket`.

The project structure is also different from the convention as it does not use any dependency management, currently [`dep`](https://github.com/golang/dep) is suggested but it can take another PR by itself.